### PR TITLE
UGC-4353 | Add cache to HeaderFooter content

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -18,7 +18,7 @@
 	"HookHandlers": {
 		"main": {
 			"class": "HeaderFooter",
-			"services": ["MainConfig"]
+			"services": ["MainConfig", "MainWANObjectCache"]
 		}
 	},
 	"Hooks": {

--- a/tests/phpunit/unit/HeaderFooterTest.php
+++ b/tests/phpunit/unit/HeaderFooterTest.php
@@ -226,6 +226,9 @@ class HeaderFooterTest extends MediaWikiUnitTestCase {
 			'HeaderFooterEnableAsyncFooter' => false
 		];
 
-		return new HeaderFooter( new HashConfig( $configOverrides + $configDefaults ) );
+		return new HeaderFooter(
+			new HashConfig( $configOverrides + $configDefaults ),
+			WANObjectCache::newEmpty()
+		);
 	}
 }


### PR DESCRIPTION
HeaderFooter messages can be expensive to parse, so add a short TTL memcache around them to reduce their impact.